### PR TITLE
Fix wrong env var for OPENAI_MAX_TEMPERATURE in docs

### DIFF
--- a/docs/configuration/providers.md
+++ b/docs/configuration/providers.md
@@ -18,7 +18,7 @@ export OPENAI_API_KEY=your_api_key_here
 
 Other OpenAI-related environment variables are supported:
 
-- `OPENAI_TEMPERATURE` - temperature model parameter, defaults to 0
+- `OPENAI_MAX_TEMPERATURE` - temperature model parameter, defaults to 0
 - `OPENAI_MAX_TOKENS` - max_tokens model parameter, defaults to 1024
 
 The OpenAI provider supports the following model formats:


### PR DESCRIPTION
@typpo honestly, should considering renaming the env var to OPENAI_TEMPERATURE cos max temperature doesn't really make sense.