### PR TITLE
Linking docs together, improves Python example

### DIFF
--- a/docs/configuration/parameters.md
+++ b/docs/configuration/parameters.md
@@ -139,3 +139,14 @@ The results of the evaluation are written to this file. Each record in the outpu
 For example outputs, see the [examples/](https://github.com/typpo/promptfoo/tree/main/examples/simple-cli) directory.
 
 The output file is specified by the `outputPath` key in the promptfoo configuration.
+
+## Permuting both inputs and assertions
+
+A vanilla `prompts.txt`/`promptfooconfig.yaml` pair supports
+each test combining one set of variables with one set of assertions.
+To use different variables with the same assertions,
+a separate test entry needs to be made.
+
+[Scenarios](/docs/configuration/scenarios.md)
+enables one to use all possible combinations of 1+ sets of variables
+and 1+ sets of assertions within one test entry.

--- a/docs/configuration/parameters.md
+++ b/docs/configuration/parameters.md
@@ -144,9 +144,9 @@ The output file is specified by the `outputPath` key in the promptfoo configurat
 
 A vanilla `prompts.txt`/`promptfooconfig.yaml` pair supports
 each test combining one set of variables with one set of assertions.
-To use different variables with the same assertions,
-a separate test entry needs to be made.
+Trying to combine many sets of variables with many sets of assertions
+can lead to exponentially more config entries.
 
 [Scenarios](/docs/configuration/scenarios.md)
 enables one to use all possible combinations of 1+ sets of variables
-and 1+ sets of assertions within one test entry.
+and 1+ sets of assertions within one config entry.

--- a/docs/configuration/parameters.md
+++ b/docs/configuration/parameters.md
@@ -93,14 +93,18 @@ module.exports.prompt1 = async function ({ vars }) {
 ```
 
 A Python prompt function, `prompt.py`:
+
 ```python title=prompt.py
-import sys
 import json
+import sys
 
-def generate_prompt(context):
-    return f'Describe {context["vars"]["topic"]} concisely, comparing it to the Python programming language.'
+def generate_prompt(context: dict) -> str:
+    return (
+        f"Describe {context['vars']['topic']} concisely, comparing it to the Python"
+        " programming language."
+    )
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print(generate_prompt(json.loads(sys.argv[1])))
 ```
 

--- a/docs/configuration/parameters.md
+++ b/docs/configuration/parameters.md
@@ -110,21 +110,23 @@ if __name__ == "__main__":
 
 ## Tests File
 
-The tests file is an optional CSV file that can be used to define test cases separately from the main configuration.
+The tests file is an optional CSV file that can be used to define test cases
+separately from the `promptfooconfig` configuration file.
 
-The first row of the CSV file should contain the variable names, and each subsequent row should contain the corresponding values for each test case.
+The first row of the CSV file should contain the variable names,
+and each subsequent row should contain the corresponding values for each test case.
 
 Vars are substituted by [Nunjucks](https://mozilla.github.io/nunjucks/) templating syntax into prompts. The first row is the variable names. All other rows are variable values.
 
 Example of a tests file (`tests.csv`):
 
-```
+```csv
 language,input
 German,"Hello, world!"
 Spanish,Where is the library?
 ```
 
-The vars file optionally supports some special columns:
+The tests file optionally supports several special columns:
 
 - `__expected`: A column that includes [test assertions](/docs/configuration/expected-outputs). This column lets you automatically mark output according to quality expectations.
 - `__prefix`: This string is prepended to each prompt before it's sent to the API

--- a/docs/configuration/reference.md
+++ b/docs/configuration/reference.md
@@ -119,7 +119,8 @@ interface UnifiedConfig {
 
 ### Scenario
 
-Scenario is an object that represents a group of test cases to be evaluated. It includes a description, default test case configuration, and a list of test cases.
+`Scenario` is an object that represents a group of test cases to be evaluated.
+It includes a description, default test case configuration, and a list of test cases.
 
 ```typescript
 interface Scenario {
@@ -128,6 +129,9 @@ interface Scenario {
   tests: TestCase[];
 }
 ```
+
+Also, see [this table here](/docs/configuration/scenarios#configuration)
+for descriptions.
 
 ### EvaluateOptions
 


### PR DESCRIPTION
- Cleans up Python example (blackens, isorts, adds type hints)
- Corrects "vars file" to "tests file" in `parameters.md`
- Links Scenarios docs in inputs/outputs file
- Links Scenarios table in references (ameliorates https://github.com/promptfoo/promptfoo/issues/169)