### PR TITLE
Docs fix on similarity vs similar

### DIFF
--- a/docs/configuration/expected-outputs.md
+++ b/docs/configuration/expected-outputs.md
@@ -378,6 +378,7 @@ You may also return a score:
 The `similar` assertion checks if an embedding of the LLM's output
 is semantically similar to the expected value,
 using a cosine similarity threshold.
+
 By default, embeddings are computed via OpenAI's `text-embedding-ada-002` model.
 
 Example:

--- a/docs/configuration/expected-outputs.md
+++ b/docs/configuration/expected-outputs.md
@@ -375,7 +375,10 @@ You may also return a score:
 
 ### Similarity
 
-The `similarity` assertion checks if the LLM output is semantically similar to the expected value, using a cosine similarity threshold.
+The `similarity` assertion checks if an embedding of the LLM's output
+is semantically similar to the expected value,
+using a cosine similarity threshold.
+By default, embeddings are computed via OpenAI's `text-embedding-ada-002` model.
 
 Example:
 

--- a/docs/configuration/expected-outputs.md
+++ b/docs/configuration/expected-outputs.md
@@ -375,7 +375,7 @@ You may also return a score:
 
 ### Similarity
 
-The `similarity` assertion checks if an embedding of the LLM's output
+The `similar` assertion checks if an embedding of the LLM's output
 is semantically similar to the expected value,
 using a cosine similarity threshold.
 By default, embeddings are computed via OpenAI's `text-embedding-ada-002` model.


### PR DESCRIPTION
- Fixed `similar` vs `similarity` in docs
- Upstreaming knowledge of embeddings from https://github.com/promptfoo/promptfoo/issues/146#issuecomment-1722085670